### PR TITLE
chore: Fix meta & title tags for SEO

### DIFF
--- a/docs-src/src/Headers.js
+++ b/docs-src/src/Headers.js
@@ -6,9 +6,12 @@ const Headers = ({children, extraKeywords, metaDescription, title}) => {
   const keywordString = extraKeywords ? `, ${extraKeywords}` : ''
   let extendedTitle = `${title} | Harmonium | React Components for Teams That Move Fast`
 
-  if (extendedTitle.length >= 70) {
-    // Trim title down if it is over 70 characters for better display & indexing
+  if (extendedTitle.length >= 60) {
+    // Trim title down if it is over 60 characters for better display & indexing
     extendedTitle = `${title} | Harmonium | React Components`
+    if (extendedTitle.length >= 60) {
+      extendedTitle = `${title} | Harmonium`
+    }
   }
 
   return (

--- a/docs-src/src/pages/components/Map/DefaultMap.js
+++ b/docs-src/src/pages/components/Map/DefaultMap.js
@@ -13,7 +13,11 @@ export default class DefaultMapExamplePage extends Component {
       <div>
         <Headers
           title="Default Map Component"
-          metaDescription={'This is a Map Component'}
+          metaDescription={
+            'This is a Default Map Component, no zoom or styles have been given' +
+            'as props. An address (a string) has been provided as the center' +
+            'props rather than an object with latitude and longitude.'
+          }
           extraKeywords="Map"
         >
           <p>

--- a/docs-src/src/pages/components/Map/DesignedRetroMap.js
+++ b/docs-src/src/pages/components/Map/DesignedRetroMap.js
@@ -13,7 +13,11 @@ export default class DesignedRetroMapExamplePage extends Component {
       <div>
         <Headers
           title="Designed Retro Map Component"
-          metaDescription={'This is a Map Component'}
+          metaDescription={
+            'This is a Designed Retro Map Component, we have passed the' +
+            'RetroStyle as a styles props to Map. A zoom, object center (latitude' +
+            'and longitude) and style have been provided as props.'
+          }
           extraKeywords="Map"
         >
           <p>

--- a/docs-src/src/pages/components/Map/DesignedSilverMap.js
+++ b/docs-src/src/pages/components/Map/DesignedSilverMap.js
@@ -13,7 +13,11 @@ export default class DesignedSilverMapExamplePage extends Component {
       <div>
         <Headers
           title="Small Designed Silver Map Component"
-          metaDescription={'This is a Map Component'}
+          metaDescription={
+            'This is a Small Designed Silver Map Component, we have passed' +
+            '"small" as a prop to the Map component. There is a small, medium and' +
+            'large props.'
+          }
           extraKeywords="Map"
         >
           <p>

--- a/docs-src/src/pages/components/Map/HybridMap.js
+++ b/docs-src/src/pages/components/Map/HybridMap.js
@@ -13,7 +13,11 @@ export default class HybridMapExamplePage extends Component {
       <div>
         <Headers
           title="Hybrid Map Component"
-          metaDescription={'This is a Map Component'}
+          metaDescription={
+            'This is an Hybrid Map Component, a zoom and style have been given as' +
+            'props. An address (a string) has been provided as the center props' +
+            'rather than an object with latitude and longitude.'
+          }
           extraKeywords="Map"
         >
           <p>

--- a/docs-src/src/pages/components/Sticky.js
+++ b/docs-src/src/pages/components/Sticky.js
@@ -21,8 +21,7 @@ export default class StickyExamplePage extends Component {
             'The Sticky component is a container that "sticks" to an edge of the ' +
             'browser window as it is scrolled. It is typically used for navigation ' +
             'elements or important messages that should remain in sight as the user ' +
-            'scrolls. It should be used sparingly only when the contents are ' +
-            'important, because it takes up space and distracts the user.'
+            'scrolls.'
           }
           extraKeywords="Component, Sticky, Layout, Navigation"
         >


### PR DESCRIPTION
We have some pages with titles that are still too long for Google. We have pages with descriptions that were too short (and not very descriptive). We had a page with a description too long to fit in google. This fixes those miscellaneous technical SEO lints.