### PR TITLE
#241 logo size in topbar component

### DIFF
--- a/docs-src/src/examples/TopBar/TopBar.js.example
+++ b/docs-src/src/examples/TopBar/TopBar.js.example
@@ -1,6 +1,6 @@
 <div>
   <TopBar>
-    <Brand linkPath="/" imagePath="https://logo.clearbit.com/revelry.co?s=128" altTag="logo alt tag" />
+    <Brand linkPath="/" imagePath="/images/harmonium-symbol.png" altTag="logo alt tag" />
     <TopBar.Item>
       <Menu horizontalLeft>
         <Menu.Item><a href="#">One</a></Menu.Item>

--- a/docs-src/src/examples/TopBar/TopBarCenter.js.example
+++ b/docs-src/src/examples/TopBar/TopBarCenter.js.example
@@ -1,5 +1,5 @@
 <TopBar center>
-  <Brand linkPath="/" imagePath="https://logo.clearbit.com/revelry.co?s=128" altTag="logo alt tag" />
+  <Brand linkPath="/" imagePath="/images/harmonium-symbol.png" altTag="logo alt tag" />
   <TopBar.Item>
     <Menu horizontalLeft>
       <Menu.Item><a href="#">One</a></Menu.Item>

--- a/docs-src/src/layouts/Navigation.js
+++ b/docs-src/src/layouts/Navigation.js
@@ -14,7 +14,7 @@ export default function Navigation() {
       left
     >
       <nav>
-        <Link className="rev-Brand Hide--smallOnly" to="/">
+        <Link className="rev-Brand ExampleBrand Hide--smallOnly" to="/">
           <img src="/images/harmonium-logo-white.png" alt="Harmonium"/>
           <small>Version {packageInfo.version}</small>
         </Link>

--- a/docs-src/src/layouts/index.js
+++ b/docs-src/src/layouts/index.js
@@ -52,7 +52,7 @@ const TemplateWrapper = ({children, location}) => (
       />
     </Helmet>
     <TopBar className="Show--smallOnly">
-      <Link className="rev-Brand Show--smallOnly" to="/">
+      <Link className="rev-Brand ExampleBrand Show--smallOnly" to="/">
         <img src="/images/harmonium-logo.png" alt="Harmonium"/>
         <small>Version {packageInfo.version}</small>
       </Link>

--- a/docs-src/src/layouts/index.scss
+++ b/docs-src/src/layouts/index.scss
@@ -231,7 +231,7 @@ h6 {
 }
 
 // Branding
-.rev-Brand {
+.ExampleBrand {
   @include flex(center, row, center, nowrap);
   height: 48px;
   padding: $global-padding-tiny $global-padding-small;

--- a/scss/components/_Brand.scss
+++ b/scss/components/_Brand.scss
@@ -3,5 +3,10 @@
   padding-left: $grid-column-padding;
   padding-right: $grid-column-padding;
   height: 100%;
+}
+
+.rev-Brand-img {
+  height: 100%;
   width: auto;
+  padding: $global-padding-tiny 0;
 }

--- a/src/Brand.js
+++ b/src/Brand.js
@@ -4,8 +4,7 @@ import classNames from 'classnames'
 
 export default class Brand extends Component {
   static propTypes = {
-    children: PropTypes.oneOfType([PropTypes.string, PropTypes.node])
-      .isRequired,
+    children: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
     className: PropTypes.string,
     imagePath: PropTypes.string,
     altTag: PropTypes.string,
@@ -26,7 +25,7 @@ export default class Brand extends Component {
 
     return (
       <a href={linkPath} className={newClassName} {...props}>
-        <img className="ref-Brand-img" src={imagePath} alt={altTag} />
+        <img className="rev-Brand-img" src={imagePath} alt={altTag} />
         {children}
       </a>
     )

--- a/src/Brand.test.js
+++ b/src/Brand.test.js
@@ -5,31 +5,28 @@ import {shallow} from 'enzyme'
 const props = {}
 
 describe('Brand', () => {
-  it('will shallow render without throwing', () => {
+  it('should render without throwing', () => {
     expect(() => shallow(<Brand {...props} />)).not.to.throw()
   })
 
-  it('will set the src on the img element', () => {
-    const brand = shallow(<Brand imagePath="path/to/image" />)
+  it('should set the "src" attribute on the image element', () => {
+    const path = 'path/to/image'
+    const brand = shallow(<Brand imagePath={path} />)
 
-    expect(brand.find('img').html()).to.equal(
-      '<img class="ref-Brand-img" src="path/to/image"/>'
-    )
+    expect(brand.find('img').getElement().props.src).to.equal(path)
   })
 
-  it('will set the alt tag on the img element', () => {
-    const brand = shallow(<Brand altTag="screen reader text" />)
+  it('should set the "alt" tag on the image element', () => {
+    const altText = 'screen reader text'
+    const brand = shallow(<Brand altTag={altText} />)
 
-    expect(brand.find('img').html()).to.equal(
-      '<img class="ref-Brand-img" alt="screen reader text"/>'
-    )
+    expect(brand.find('img').getElement().props.alt).to.equal(altText)
   })
 
-  it('will set the link url on the anchor element', () => {
-    const brand = shallow(<Brand linkPath="/example" />)
+  it('should set the link on the anchor element', () => {
+    const link = '/some/example/link'
+    const brand = shallow(<Brand linkPath={link} />)
 
-    expect(brand.find('a').html()).to.equal(
-      '<a href="/example" class="rev-Brand"><img class="ref-Brand-img"/></a>'
-    )
+    expect(brand.find('a').getElement().props.href).to.equal(link)
   })
 })


### PR DESCRIPTION
#241 

- [x]  Fix logo styles so that it doesn't overflow the bounds of the TopBar
- [x]  Fix alignment when the "logo" is just text and not an image
- [x]  Fix spelling: ref-Brand-img should be rev-Brand-img