### PR TITLE
button fix

### DIFF
--- a/scss/components/_Buttons.scss
+++ b/scss/components/_Buttons.scss
@@ -142,6 +142,7 @@ $button-radius: $global-radius !default;
   }
 }
 .rev-ButtonGroup {
+  font-size: 0;
   .rev-Button {
     border-radius: 0;
     border-right: 1px solid $divider-color;


### PR DESCRIPTION
connects to #337

- .rev-Buttons in a .rev-ButtonGroup had spacing between them **when used in an actual project** I think this wasn't happening on harmonium.revelry.co possibly because of styles added to the playground?? Can't confirm this.. but I paired with Blaze on a project and saw the issue and tested the fix
- we added font-size: 0 to the .rev-ButtonGroup so that no character spacing gets added between buttons in a buttongroup

<img width="704" alt="screen shot 2018-10-15 at 11 02 50 am" src="https://user-images.githubusercontent.com/3287583/46963038-4656bb00-d06a-11e8-8777-14c7037510b2.png">
