### PR TITLE
FIX - removes file input name when  signed

### DIFF
--- a/src/MediaUploader.js
+++ b/src/MediaUploader.js
@@ -146,7 +146,7 @@ class MediaUploader extends Component {
   getFileInputName() {
     const {getS3Info, name} = this.props
 
-    return getS3Info ? 'false' : name
+    return getS3Info ? '' : name
   }
 
   getRequired() {

--- a/src/MediaUploader.test.js
+++ b/src/MediaUploader.test.js
@@ -41,7 +41,7 @@ describe('MediaUploader', () => {
     )
 
     expect(
-      wrapper.find('input[type="file"][name="false"][required=false]').length
+      wrapper.find('input[type="file"][name=""][required=false]').length
     ).to.equal(1)
     expect(
       wrapper.find('input[type="hidden"][name="image"][required]').length


### PR DESCRIPTION
Made a change that sets the name of the file input in `MediaUploader` to and empty string when using signed upload. This prevents file from being submitted with form after s3 upload. 