### PR TITLE
removed global padding from rev content

### DIFF
--- a/scss/components/_ContentWrapper.scss
+++ b/scss/components/_ContentWrapper.scss
@@ -4,7 +4,7 @@
   width: 100%;
 }
 .rev-Content {
-  padding: 0 $global-padding;
+  padding: 0;
   min-width: 0;
   width: 100%;
 }


### PR DESCRIPTION
Connect #378 

This looks a little funny on harmonium but I think @vegasgeek needed to use a component that has the `.rev-Content` class which includes padding by default. no test included for the minor change. first working session, lmk if this is ok! :)