### PR TITLE
Resolve test errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
   - '8'
-  - '6'
 before_deploy:
   - npm install
 deploy:

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@semantic-release/npm": "^5.1.3",
     "babel-cli": "^6.24.1",
     "babel-eslint": "^10.0.1",
-    "babel-plugin-istanbul": "^5.1.0",
+    "babel-plugin-istanbul": "^4.1.4",
     "babel-plugin-transform-decorators": "^6.24.1",
     "babel-polyfill": "^6.23.0",
     "babel-preset-es2015": "^6.24.1",


### PR DESCRIPTION
Output of the error that this fixes:

```
+npx nyc mocha './src/**/*.test.js' --opts ./mocha.opts
/home/travis/build/revelrylabs/harmonium/node_modules/mocha/node_modules/yargs/yargs.js:1163
      else throw err
           ^
Error: /home/travis/build/revelrylabs/harmonium/src/Accordion.js: You gave us a visitor for the node type "ClassPrivateProperty" but it's not a valid type
```