### PR TITLE
chore: reference harmonium in docs-src package.json using the file syntax

### DIFF
--- a/docs-src/package.json
+++ b/docs-src/package.json
@@ -29,7 +29,8 @@
     "react-dom": "^16.8.6",
     "react-helmet": "^5.2.1",
     "react-router-dom": "^5.0.1",
-    "yarn": "^1.17.3"
+    "yarn": "^1.17.3",
+    "harmonium": "file:.."
   },
   "keywords": [
     "gatsby"
@@ -42,7 +43,7 @@
     "format": "prettier --trailing-comma es5 --no-semi --single-quote --write 'src/**/*.js'",
     "test": "echo \"Error: no test specified\" && exit 1",
     "cache:rebuild": "rm -r node_modules || rm -r package-lock.json || yarn cache clean && yarn install --force",
-    "postinstall": "(cd .. && npm run prepare) && ln -s ../.. node_modules/harmonium"
+    "postinstall": "(cd .. && npm run prepare)"
   },
   "devDependencies": {
     "mini-css-extract-plugin": "^0.9.0"


### PR DESCRIPTION
This PR removes the symlinking of the harmonium folder. It instead uses npm's `file:` syntax. This should stop the symlink from being removed when installing packages (because npm will handle it) and do things more idiomatically 