### PR TITLE
chore: Put React and HTML output into tabs

### DIFF
--- a/docs-src/package.json
+++ b/docs-src/package.json
@@ -8,7 +8,6 @@
     "@babel/preset-env": "^7.5.5",
     "babel-plugin-prismjs": "^2.0.1",
     "babel-preset-gatsby": "^0.2.27",
-    "component-playground": "^3.2.1",
     "gatsby": "^2.19.2",
     "gatsby-cli": "^2.7.26",
     "gatsby-image": "^2.2.8",

--- a/docs-src/package.json
+++ b/docs-src/package.json
@@ -20,17 +20,20 @@
     "gatsby-plugin-sharp": "^2.2.9",
     "gatsby-source-filesystem": "^2.1.8",
     "gatsby-transformer-sharp": "^2.2.5",
+    "harmonium": "file:..",
     "node-sass": "^4.12.0",
     "prettier": "^1.5.2",
+    "prism-react-renderer": "^1.0.2",
     "prismjs": "^1.19.0",
     "prop-types": "^15.7.2",
     "raw-loader": "^4.0.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-helmet": "^5.2.1",
+    "react-live": "^2.2.2",
     "react-router-dom": "^5.0.1",
-    "yarn": "^1.17.3",
-    "harmonium": "file:.."
+    "react-syntax-highlighter": "^12.2.1",
+    "yarn": "^1.17.3"
   },
   "keywords": [
     "gatsby"

--- a/docs-src/src/ExampleSection.js
+++ b/docs-src/src/ExampleSection.js
@@ -1,53 +1,83 @@
-import React, { useEffect } from 'react';
+import React, { useState } from 'react';
 import {Row, Col} from 'harmonium/lib/grid'
-import Playground from 'component-playground'
-import Prism from 'prismjs'
 import prettier from 'prettier/standalone';
 import prettierHTML from 'prettier/parser-html'
+import {
+  LiveProvider,
+  LiveEditor,
+  LiveError,
+  LivePreview,
+  withLive
+} from 'react-live'
+import theme from "prism-react-renderer/themes/palenight";
+import ReactDOMServer from "react-dom/server";
+import Highlight, { defaultProps } from "prism-react-renderer";
 
-// Use requestAnimationFrame to add in HTML previews
-function renderHTMLExamples(previewAreas){
-  function worker(index){
-    if(index == previewAreas.length){
-      return;
-    }
+function HTML({ live }) {
+  const Result = live.element;
+  const html = ReactDOMServer.renderToStaticMarkup(<Result />);
+  const formattedHTML = prettier.format(html, {parser: 'html', plugins: [prettierHTML]})
 
-    const previewArea = previewAreas[index];
-    const parent = previewArea.closest('.rev-Col')
-    const htmlPreviewArea = parent.querySelector('.htmlPreviewArea')
-    if(htmlPreviewArea){
-      htmlPreviewArea.textContent = prettier.format(previewArea.innerHTML, {parser: 'html', plugins: [prettierHTML]})
-      Prism.highlightElement(htmlPreviewArea);
-    }
-
-    var nextFunction = worker.bind(this, index + 1);
-    window.requestAnimationFrame(nextFunction);
-  }
-
-  var nextFunction = worker.bind(this, 0);
-  window.requestAnimationFrame(nextFunction);
+  return (
+    <Highlight {...defaultProps} code={formattedHTML} language="markup" theme={theme}>
+        {({ className, style, tokens, getLineProps, getTokenProps }) => (
+          <pre className={className} style={style}>
+            {tokens.map((line, i) => (
+              <div {...getLineProps({ line, key: i })}>
+                {line.map((token, key) => (
+                  <span {...getTokenProps({ token, key })} />
+                ))}
+              </div>
+            ))}
+          </pre>
+        )}
+      </Highlight>
+  );
 }
 
+const LiveHTML = withLive(HTML);
+
 export default function ExampleSection(props) {
-  useEffect(() => {
-    if(!props.disableHTMLPreview){
-      renderHTMLExamples(document.querySelectorAll('.previewArea'))
-    }
-  });
+  const [active, setActive] = useState(1);
 
   if (typeof props.examples === 'string') {
     return (
-      <React.Fragment>
-        <Playground theme="lucario" collapsableCode={true} codeText={props.examples} scope={props.scope} />
-        {
-          props.disableHTMLPreview ? null : (<section className="HTMLCodeSection">
-          <h3>HTML</h3>
-          <pre>
-            <code className="language-markup htmlPreviewArea"></code>
-          </pre>
-        </section>)
-        }
-      </React.Fragment>
+      <div className="example-section HTMLCodeSection">
+        <LiveProvider theme={theme} code={props.examples} scope={props.scope}>
+          <LiveError />
+          <LivePreview className="example-preview" />
+          <div className="rev-Tabs">
+        <ul className="rev-Tabs-titles">
+          <li className={`rev-TabsTitle ${active === 1 && "rev-TabsTitle--selected"}`}>
+            <a className="rev-TabsTitle-link" onClick={() => setActive(1)}>React</a>
+          </li>
+          <li className={`rev-TabsTitle ${active === 2 && "rev-TabsTitle--selected"}`}>
+            <a className="rev-TabsTitle-link" onClick={() => setActive(2)}>HTML</a>
+          </li>
+        </ul>
+        <div className="rev-Tabs-content">
+          <div
+            className={`rev-TabsItem-panel ${active === 1 && "rev-TabsItem-panel--selected"}`}
+          >
+            <div className="rev-Row">
+              <div className="rev-Col">
+                <LiveEditor className="example-react-code" />
+              </div>
+            </div>
+          </div>
+          <div
+            className={`rev-TabsItem-panel ${active === 2 && "rev-TabsItem-panel--selected"}`}
+          >
+            <div className="rev-Row">
+              <div className="rev-Col">
+                <LiveHTML />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      </LiveProvider>
+      </div>
     )
   } else {
     const children = []

--- a/docs-src/src/ExampleSection.js
+++ b/docs-src/src/ExampleSection.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import {Row, Col} from 'harmonium/lib/grid'
+import Tabs from 'harmonium/lib/Tabs'
 import prettier from 'prettier/standalone';
 import prettierHTML from 'prettier/parser-html'
 import {
@@ -38,45 +39,29 @@ function HTML({ live }) {
 const LiveHTML = withLive(HTML);
 
 export default function ExampleSection(props) {
-  const [active, setActive] = useState(1);
-
   if (typeof props.examples === 'string') {
     return (
       <div className="example-section HTMLCodeSection">
         <LiveProvider theme={theme} code={props.examples} scope={props.scope}>
           <LiveError />
           <LivePreview className="example-preview" />
-          <div className="rev-Tabs">
-        <ul className="rev-Tabs-titles">
-          <li className={`rev-TabsTitle ${active === 1 && "rev-TabsTitle--selected"}`}>
-            <a className="rev-TabsTitle-link" onClick={() => setActive(1)}>React</a>
-          </li>
-          <li className={`rev-TabsTitle ${active === 2 && "rev-TabsTitle--selected"}`}>
-            <a className="rev-TabsTitle-link" onClick={() => setActive(2)}>HTML</a>
-          </li>
-        </ul>
-        <div className="rev-Tabs-content">
-          <div
-            className={`rev-TabsItem-panel ${active === 1 && "rev-TabsItem-panel--selected"}`}
-          >
-            <div className="rev-Row">
-              <div className="rev-Col">
-                <LiveEditor className="example-react-code" />
-              </div>
-            </div>
-          </div>
-          <div
-            className={`rev-TabsItem-panel ${active === 2 && "rev-TabsItem-panel--selected"}`}
-          >
-            <div className="rev-Row">
-              <div className="rev-Col">
-                <LiveHTML />
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      </LiveProvider>
+          <Tabs.Stateful>
+            <Tabs.Item contentKey={1} title="React">
+              <Row>
+                <Col>
+                  <LiveEditor className="example-react-code" />
+                </Col>
+              </Row>
+            </Tabs.Item>
+            <Tabs.Item contentKey={2} title="HTML">
+              <Row>
+                <Col>
+                  <LiveHTML />
+                </Col>
+              </Row>
+            </Tabs.Item>
+          </Tabs.Stateful>
+        </LiveProvider>
       </div>
     )
   } else {
@@ -89,7 +74,6 @@ export default function ExampleSection(props) {
             examples={props.examples[examplesTitle]}
             scope={props.scope}
             key={examplesTitle}
-            disableHTMLPreview={props.disableHTMLPreview}
           />
         )
       }

--- a/docs-src/src/ExampleSection.js
+++ b/docs-src/src/ExampleSection.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import {Row, Col} from 'harmonium/lib/grid'
 import Tabs from 'harmonium/lib/Tabs'
 import prettier from 'prettier/standalone';

--- a/docs-src/src/layouts/index.scss
+++ b/docs-src/src/layouts/index.scss
@@ -7,13 +7,18 @@
   border-color: mix($alert, $white, 33%);
   color: mix($alert, $white, 33%);
 }
+
 // TYPOGRAPHY
 
 // Proxima Nova Headers for docs only
-h1,h2,h3,h4 {
+h1,
+h2,
+h3,
+h4 {
   font-family: 'proxima-nova', $global-sans-serif-font;
   font-weight: 500;
 }
+
 //TODO incorporate this into typography styles
 h1 {
   font-size: 36px;
@@ -21,10 +26,12 @@ h1 {
   margin: 0;
   padding: $global-padding-large 0 $global-padding-small;
 }
+
 h2 {
   font-size: 32px;
   line-height: 48px;
 }
+
 h5,
 h6 {
   font-weight: normal;
@@ -32,34 +39,42 @@ h6 {
   padding: $global-padding 0 0;
   text-transform: uppercase;
 }
+
 code {
   background: darken($lightest-gray, 1%);
   border: 1px solid $black-03;
   padding: 0 5px;
 }
+
 .CodeMirror.CodeMirror {
   height: auto;
 }
+
 .CodeMirror-line.CodeMirror-line {
   font-size: $global-font-size-small;
   line-height: $global-vertical-space;
   padding: 0;
 }
+
 .CodeMirror-lines.CodeMirror-lines {
   padding: $global-vertical-space / 4 0;
 }
+
 .CodeMirror-scroll {
   margin-left: $global-margin;
 }
+
 .playground {
   display: flex;
   flex-wrap: wrap;
   margin-bottom: $global-margin-large;
 }
+
 .playgroundToggleCodeBar {
   margin: 0 $global-padding-small -1px;
   order: 1;
 }
+
 .playgroundToggleCodeLink {
   @include flex(center, row, flex-start, nowrap);
   background: $lightest-gray;
@@ -70,23 +85,28 @@ code {
   cursor: pointer;
   padding: $global-padding-tiny $global-padding-small;
   position: relative;
+
   &:hover {
     color: $anchor-color-hover;
   }
+
   &:active,
   &:focus {
     color: $anchor-color-active;
   }
+
   &:after {
     content: 'code snippet';
     padding-left: $global-padding-tiny;
   }
+
   &:before {
     content: '+';
     font-weight: bold;
     padding-right: $global-padding-tiny;
   }
 }
+
 .playgroundCode {
   background: $lightest-gray;
   border: 1px solid $lighter-gray;
@@ -96,16 +116,19 @@ code {
   margin: 0 $global-padding-small;
   padding: $global-padding-small;
   width: 100%;
+
   .ReactCodeMirror {
     @include global-transition;
     @include vertical-scroll-container(150px);
     border-radius: $global-radius;
   }
+
   &.expandedCode {
     .ReactCodeMirror {
       max-height: 100%;
     }
-    + .playgroundToggleCodeBar {
+
+    +.playgroundToggleCodeBar {
       .playgroundToggleCodeLink {
         &:before {
           content: '-';
@@ -122,11 +145,13 @@ code {
   overflow-x: scroll;
   white-space: pre-wrap;
 }
+
 .playgroundPreview {
   display: block;
   order: 0;
   width: 100%;
 }
+
 .playgroundPreview--FakeViewportContainer {
   .playgroundPreview {
     background: url('https://3ulsmb4eg8vz37c0vz2si64j-wpengine.netdna-ssl.com/wp-content/uploads/2016/07/75ff3f3c-4aa5-11e6-9c23-4491699777fe.jpg');
@@ -139,20 +164,25 @@ code {
     width: 100%;
   }
 }
+
 // For grid example pages, colorize columns and mark the edges, and put spacing between rows
 .ColumnExamples {
+
   &.rev-Row,
   .rev-Row {
     margin-bottom: $global-margin;
+
     .rev-Row {
       margin-bottom: 0;
     }
   }
+
   .rev-Col {
     // bottom and top padding for demo purposes only
     padding-bottom: $global-padding;
     padding-top: $global-padding;
     text-align: center;
+
     // All of this is a way to put an outline-esque border on the left and
     // right edge without taking up space (doing it this way, because outline
     // can't be applied to only left and right).
@@ -172,30 +202,38 @@ code {
       top: 0;
     }
   }
+
   // Throw some grayscale colors on the grid columns to show what space they
   // occupy
   .rev-Col:nth-child(6n + 1) {
     @include color-stack($lightest-gray);
   }
+
   .rev-Col:nth-child(6n + 2) {
     @include color-stack($lighter-gray);
   }
+
   .rev-Col:nth-child(6n + 3) {
     @include color-stack($light-gray);
   }
+
   .rev-Col:nth-child(6n + 4) {
     @include color-stack($gray);
   }
+
   .rev-Col:nth-child(6n + 5) {
     @include color-stack($dark-gray);
   }
+
   .rev-Col:nth-child(6n + 6) {
     @include color-stack($darker-gray);
   }
+
   // For nesting example, show the extents of the nested row
   .rev-Col .rev-Row {
     outline: 1px solid $white;
   }
+
   // removing the bkgd on Block Grid so that kitty images look better
   &.ColumnExamples--blockGrid {
     .rev-Col {
@@ -204,6 +242,7 @@ code {
     }
   }
 }
+
 // Bkgd Colors
 .ExampleBkgd--primary {
   background: $primary;
@@ -211,17 +250,20 @@ code {
   margin-bottom: $global-padding;
   padding: $global-padding $global-padding 0;
 }
+
 // Color Swatches
 .ExampleSwatches {
   @include aspect-ratio(1, 1);
   @include color-management;
 }
+
 // Buttons
 .ExampleButtons {
   .rev-Button {
     margin-right: $global-margin;
   }
 }
+
 // Visibility
 .ExampleVisibility {
   padding: $global-padding;
@@ -242,19 +284,23 @@ code {
   height: 48px;
   padding: $global-padding-tiny $global-padding-small;
   position: relative;
+
   @include breakpoint(medium) {
     margin: $global-margin-large 0 $global-margin;
     padding: 0 $global-padding;
   }
+
   img {
     height: 100%;
     width: auto;
+
     @include breakpoint(medium) {
       height: auto;
       margin-bottom: $global-padding-small;
       width: 100%
     }
   }
+
   small {
     bottom: -1.2rem;
     color: $white-60;
@@ -264,6 +310,7 @@ code {
     position: absolute;
   }
 }
+
 .rev-Brand-symbol {
   margin: $global-margin-large auto $global-margin;
   max-width: 20rem;
@@ -275,6 +322,7 @@ code {
     box-shadow: 0 0 3px 0 $black-20;
     border: 0;
     margin-bottom: $global-margin;
+
     small {
       color: $white-60;
       font-size: $global-font-size-small;
@@ -289,6 +337,7 @@ code {
     .rev-Drawer-closer {
       color: $white-60;
       transform: rotate(0.125turn);
+
       &:hover,
       &:active,
       &:focus {
@@ -296,12 +345,15 @@ code {
       }
     }
   }
+
   @include breakpoint(small-only) {
     top: $topbar-height;
+
     &.rev-Drawer {
       .rev-Drawer-closer {
         top: $topbar-height;
       }
+
       .rev-Drawer-expander {
         background: $brand;
         border-radius: 0 $global-radius $global-radius 0;
@@ -312,32 +364,39 @@ code {
       }
     }
   }
+
   .rev-Drawer-contents {
     background: $brand;
     background: linear-gradient(to bottom, $brand-secondary 0%, $brand 100%);
     color: $white;
     padding-bottom: $global-padding-larger;
   }
+
   .rev-Menu-item--text {
     color: $white-60;
   }
+
   .rev-Menu-item a {
     color: $white-80;
     position: relative;
+
     &:hover,
     &:active,
     &:focus {
       background: $white-06;
       color: $white;
     }
+
     &:active,
     &:focus {
       background: $white-10;
     }
   }
+
   .rev-Menu-item--selected a {
     background: $white-10;
     color: $white;
+
     &:after {
       background: $white;
       border-radius: 0 $global-radius $global-radius 0;
@@ -350,6 +409,7 @@ code {
     }
   }
 }
+
 .FixedDrawerLinks {
   @include flex(stretch, row, center, nowrap);
   @include global-transition;
@@ -360,15 +420,19 @@ code {
   position: fixed;
   width: $drawer-width;
   z-index: $above;
+
   .rev-Drawer--open & {
     left: 0;
   }
+
   @include breakpoint(medium) {
     left: 0;
   }
+
   .rev-Menu-item {
     flex: 1;
     text-align: center;
+
     &:first-child {
       border-right: 1px solid $divider-color-dark;
     }
@@ -397,9 +461,6 @@ code {
   margin: 0 1.2rem;
 
   .code-toolbar {
-    background: #F4F4F4;
-    border: 1px solid #D5D5D5;
-    border-radius: 0 3px 3px 3px;
     display: block;
     padding: 1.2rem;
     width: 100%;

--- a/docs-src/src/pages/components/DatePicker.js
+++ b/docs-src/src/pages/components/DatePicker.js
@@ -46,7 +46,6 @@ export default class DatePickerExamplePage extends Component {
           examples={examples}
           depth={1}
           scope={scope}
-          disableHTMLPreview
         />
       </Layout>
     )

--- a/docs-src/src/pages/components/TimePicker.js
+++ b/docs-src/src/pages/components/TimePicker.js
@@ -40,7 +40,6 @@ export default class TimePickerExamplePage extends Component {
           examples={examples}
           depth={1}
           scope={scope}
-          disableHTMLPreview
         />
       </Layout>
     )


### PR DESCRIPTION
Replace component-playground with react-live. This is made by
FormidableLabs as well and is more supported. And allows for
more customization of layout.

<img width="949" alt="Screen Shot 2020-01-29 at 9 54 00 PM" src="https://user-images.githubusercontent.com/1257573/73418749-48d23800-42e2-11ea-806b-1e0966319034.png">

<img width="947" alt="Screen Shot 2020-01-29 at 9 54 07 PM" src="https://user-images.githubusercontent.com/1257573/73418750-4cfe5580-42e2-11ea-881b-3a5836184883.png">

