### PR TITLE
Feature - 486 add documentation pages

### DIFF
--- a/docs-src/src/pages/design-tokens.js
+++ b/docs-src/src/pages/design-tokens.js
@@ -9,14 +9,14 @@ function sortByName(itemA, itemB) {
   var nameA = itemA.name.toUpperCase(); // ignore upper and lowercase
   var nameB = itemB.name.toUpperCase(); // ignore upper and lowercase
   if (nameA < nameB) {
-    return -1;
+    return -1
   }
   if (nameA > nameB) {
-    return 1;
+    return 1
   }
 
   // names must be equal
-  return 0;
+  return 0
 }
 
 function flattenDesignTokens(category){
@@ -184,7 +184,7 @@ function Fonts() {
   )
 }
 
-function BorderRadiusRows () {
+function BorderRadiusRows() {
 
   const rows = []
   const radii = DesignTokens.border.radius
@@ -197,7 +197,8 @@ function BorderRadiusRows () {
       border: '1px solid #22222222',
     };
 
-    rows.push(<Table.Row>
+    rows.push (
+    <Table.Row>
       <Table.Data>
         <Table.HeaderInline>Token:</Table.HeaderInline>
           <pre>${radii[radius].name}</pre>
@@ -208,7 +209,8 @@ function BorderRadiusRows () {
         <div style={exampleStyle}></div>
         <pre>{radii[radius].value}</pre>
       </Table.Data>
-    </Table.Row>)
+    </Table.Row>
+    )
   }
 
   return rows
@@ -233,6 +235,34 @@ function BorderRadius() {
 }
 
 
+function ZIndexRows() {
+  
+  const rows = []
+  const zIndices = DesignTokens["z-index"]
+
+  for (const index in zIndices) {
+    const exampleStyle = {
+      zIndex: zIndices[index].value
+    };
+
+    rows.push (
+      <Table.Row>
+        <Table.Data>
+          <Table.HeaderInline>Token:</Table.HeaderInline>
+            <pre>${zIndices[index].name}</pre>
+            <p><i>{zIndices[index].comment}</i></p>
+        </Table.Data>
+        <Table.Data>
+          <Table.HeaderInline>Value:</Table.HeaderInline>
+          <pre>{zIndices[index].value}</pre>
+        </Table.Data>
+      </Table.Row>
+      )
+    }
+
+    return rows
+}
+
 function ZIndex() {
   return (
     <React.Fragment>
@@ -244,7 +274,7 @@ function ZIndex() {
             <Table.Header>Value</Table.Header>
           </Table.Row>
         </Table.Head>
-        <Table.Body></Table.Body>
+        <Table.Body>{ZIndexRows()}</Table.Body>
       </Table>
     </React.Fragment>
   )
@@ -299,6 +329,7 @@ function DesignTokensPage({location}) {
           <Fonts />
           <FontSizes />
           <BorderRadius />
+          <ZIndex />
         </Col>
       </Row>
     </Layout>

--- a/docs-src/src/pages/design-tokens.js
+++ b/docs-src/src/pages/design-tokens.js
@@ -325,6 +325,7 @@ function ShadowRows() {
       width: '10rem',
       height: '3rem',
       border: '1px solid black',
+      "box-shadow": shadows[shadow].value,
     };
 
     rows.push (

--- a/docs-src/src/pages/design-tokens.js
+++ b/docs-src/src/pages/design-tokens.js
@@ -308,32 +308,60 @@ function Spacing() {
             <Table.Header>Value</Table.Header>
           </Table.Row>
         </Table.Head>
-        <Table.Body>
-          {SpacingRows()}
-        </Table.Body>
+        <Table.Body>{SpacingRows()}</Table.Body>
       </Table>
     </React.Fragment>
   )
 }
 
-// function Shadows() {
-//   return (
-//     <React.Fragment>
-//       <h2>Shadows</h2>
-//       <Table>
-//         <Table.Head>
-//           <Table.Row>
-//             <Table.Header>Token</Table.Header>
-//             <Table.Header>Value</Table.Header>
-//           </Table.Row>
-//         </Table.Head>
-//         <Table.Body>
-//           <div style={} />
-//         </Table.Body>
-//       </Table>
-//     </React.Fragment>
-//   )
-// }
+function ShadowRows() {
+  
+  const rows = []
+  const shadows = DesignTokens.shadow
+
+  for (const shadow in shadows) {
+    const exampleStyle = {
+      shadowing: shadows[shadow].value,
+      width: '10rem',
+      height: '3rem',
+      border: '1px solid black'
+    };
+
+    rows.push (
+      <Table.Row>
+        <Table.Data>
+          <Table.HeaderInline>Token:</Table.HeaderInline>
+          <pre>${shadows[shadow].name}</pre>
+          <p><i>{shadows[shadow].comment}</i></p>
+        </Table.Data>
+        <Table.Data>
+          <Table.HeaderInline>Value:</Table.HeaderInline>
+          <div style={exampleStyle}></div>
+          {/* <pre>${shadows[shadow].value}</pre> */}
+        </Table.Data>
+      </Table.Row>
+    )
+  }
+
+  return rows
+}
+
+function Shadows() {
+  return (
+    <React.Fragment>
+      <h2>Shadows</h2>
+      <Table>
+        <Table.Head>
+          <Table.Row>
+            <Table.Header>Token</Table.Header>
+            <Table.Header>Value</Table.Header>
+          </Table.Row>
+        </Table.Head>
+        <Table.Body>{ShadowRows()}</Table.Body>
+      </Table>
+    </React.Fragment>
+  )
+}
 
 function DesignTokensPage({location}) {
   return <Layout location={location}>
@@ -348,6 +376,7 @@ function DesignTokensPage({location}) {
           <BorderRadius />
           <ZIndex />
           <Spacing />
+          <Shadows />
         </Col>
       </Row>
     </Layout>

--- a/docs-src/src/pages/design-tokens.js
+++ b/docs-src/src/pages/design-tokens.js
@@ -137,11 +137,11 @@ function FontSizes() {
   )
 }
 
-function FontRows(){
+function FontRows() {
   const rows = []
   const fontFamilies = DesignTokens.font.family
 
-  for(const font in fontFamilies){
+  for (const font in fontFamilies) {
     const exampleStyle = {
       fontFamily: fontFamilies[font].value,
     };
@@ -170,9 +170,7 @@ function Fonts() {
       <Table>
         <Table.Head>
           <Table.Row>
-            <Table.Header>
-              Token
-            </Table.Header>
+            <Table.Header>Token</Table.Header>
             <Table.Header>
               Value
             </Table.Header>
@@ -186,6 +184,110 @@ function Fonts() {
   )
 }
 
+function BorderRadiusRows () {
+
+  const rows = []
+  const radii = DesignTokens.border.radius
+
+  for (const radius in radii) {
+    const exampleStyle = {
+      borderRadius: radii[radius].value,
+      width: '10rem',
+      height: '3rem',
+      border: '1px solid #22222222',
+    };
+
+    rows.push(<Table.Row>
+      <Table.Data>
+        <Table.HeaderInline>Token:</Table.HeaderInline>
+          <pre>${radii[radius].name}</pre>
+          <p><i>{radii[radius].comment}</i></p>
+      </Table.Data>
+      <Table.Data>
+        <Table.HeaderInline>Value:</Table.HeaderInline>
+        <div style={exampleStyle}></div>
+        <pre>{radii[radius].value}</pre>
+      </Table.Data>
+    </Table.Row>)
+  }
+
+  return rows
+
+}
+
+function BorderRadius() {
+  return (
+    <React.Fragment>
+      <h2>Border Radius</h2>
+      <Table>
+        <Table.Head>
+          <Table.Row>
+            <Table.Header>Token</Table.Header>
+            <Table.Header>Value</Table.Header>
+          </Table.Row>
+        </Table.Head>
+        <Table.Body>{BorderRadiusRows()}</Table.Body>
+      </Table>
+    </React.Fragment>
+  )
+}
+
+
+function ZIndex() {
+  return (
+    <React.Fragment>
+      <h2>Z-Index</h2>
+      <Table>
+        <Table.Head>
+          <Table.Row>
+            <Table.Header>Token</Table.Header>
+            <Table.Header>Value</Table.Header>
+          </Table.Row>
+        </Table.Head>
+        <Table.Body></Table.Body>
+      </Table>
+    </React.Fragment>
+  )
+}
+
+function Spacing() {
+  return (
+    <React.Fragment>
+      <h2>Spacing</h2>
+      <Table>
+        <Table.Head>
+          <Table.Row>
+            <Table.Header>Token</Table.Header>
+            <Table.Header>Value</Table.Header>
+          </Table.Row>
+        </Table.Head>
+        <Table.Body>
+          <div style={DesignTokens.Spacing.value} />
+        </Table.Body>
+      </Table>
+    </React.Fragment>
+  )
+}
+
+// function Shadows() {
+//   return (
+//     <React.Fragment>
+//       <h2>Shadows</h2>
+//       <Table>
+//         <Table.Head>
+//           <Table.Row>
+//             <Table.Header>Token</Table.Header>
+//             <Table.Header>Value</Table.Header>
+//           </Table.Row>
+//         </Table.Head>
+//         <Table.Body>
+//           <div style={} />
+//         </Table.Body>
+//       </Table>
+//     </React.Fragment>
+//   )
+// }
+
 function DesignTokensPage({location}) {
   return <Layout location={location}>
       <Row>
@@ -196,6 +298,7 @@ function DesignTokensPage({location}) {
           <Colors />
           <Fonts />
           <FontSizes />
+          <BorderRadius />
         </Col>
       </Row>
     </Layout>

--- a/docs-src/src/pages/design-tokens.js
+++ b/docs-src/src/pages/design-tokens.js
@@ -72,17 +72,11 @@ function Colors() {
       <Table>
         <Table.Head>
           <Table.Row>
-            <Table.Header>
-              Token
-            </Table.Header>
-            <Table.Header>
-              Value
-            </Table.Header>
+            <Table.Header>Token</Table.Header>
+            <Table.Header>Value</Table.Header>
           </Table.Row>
         </Table.Head>
-        <Table.Body>
-          {ColorRows()}
-        </Table.Body>
+        <Table.Body>{ColorRows()}</Table.Body>
       </Table>
     </React.Fragment>
   )
@@ -121,17 +115,11 @@ function FontSizes() {
       <Table>
         <Table.Head>
           <Table.Row>
-            <Table.Header>
-              Token
-            </Table.Header>
-            <Table.Header>
-              Value
-            </Table.Header>
+            <Table.Header>Token</Table.Header>
+            <Table.Header>Value</Table.Header>
           </Table.Row>
         </Table.Head>
-        <Table.Body>
-          {FontSizeRows()}
-        </Table.Body>
+        <Table.Body>{FontSizeRows()}</Table.Body>
       </Table>
     </React.Fragment>
   )
@@ -171,14 +159,10 @@ function Fonts() {
         <Table.Head>
           <Table.Row>
             <Table.Header>Token</Table.Header>
-            <Table.Header>
-              Value
-            </Table.Header>
+            <Table.Header>Value</Table.Header>
           </Table.Row>
         </Table.Head>
-        <Table.Body>
-          {FontRows()}
-        </Table.Body>
+        <Table.Body>{FontRows()}</Table.Body>
       </Table>
     </React.Fragment>
   )
@@ -194,7 +178,7 @@ function BorderRadiusRows() {
       borderRadius: radii[radius].value,
       width: '10rem',
       height: '3rem',
-      border: '1px solid #22222222',
+      border: '1px solid black',
     };
 
     rows.push (
@@ -234,7 +218,7 @@ function BorderRadius() {
   )
 }
 
-
+// TODO is exampleStyle necessary here?  How can I eliminate this useless thang
 function ZIndexRows() {
   
   const rows = []
@@ -280,6 +264,8 @@ function ZIndex() {
   )
 }
 
+
+// TODO fix name not being displayed at same spacing as value!
 function SpacingRows() {
 
   const rows = []

--- a/docs-src/src/pages/design-tokens.js
+++ b/docs-src/src/pages/design-tokens.js
@@ -324,7 +324,7 @@ function ShadowRows() {
       shadowing: shadows[shadow].value,
       width: '10rem',
       height: '3rem',
-      border: '1px solid black'
+      border: '1px solid black',
     };
 
     rows.push (
@@ -337,7 +337,7 @@ function ShadowRows() {
         <Table.Data>
           <Table.HeaderInline>Value:</Table.HeaderInline>
           <div style={exampleStyle}></div>
-          {/* <pre>${shadows[shadow].value}</pre> */}
+          <pre>${shadows[shadow].value}</pre>
         </Table.Data>
       </Table.Row>
     )
@@ -363,6 +363,52 @@ function Shadows() {
   )
 }
 
+function FontWeightRows() {
+
+  const rows = []
+  const fontWeights = DesignTokens.font
+
+  for (const weight in fontWeights) {
+    const exampleStyle = {
+      fontWeight: fontWeights[weight].value,
+    };
+
+    rows.push(
+      <Table.Row>
+        <Table.Data>
+          <Table.HeaderInline>Token:</Table.HeaderInline>
+            <pre>${fontWeights[weight].name}</pre>
+            <p><i>{fontWeights[weight].comment}</i></p>
+        </Table.Data>
+        <Table.Data>
+          <Table.HeaderInline>Value:</Table.HeaderInline>
+          <div style={exampleStyle}>The quick brown fox jumped over the lazy dog.</div>
+          <pre>{fontWeights[weight].value}</pre>
+        </Table.Data>
+      </Table.Row>
+    )
+  }
+
+  return rows
+}
+
+function FontWeight() {
+  return (
+    <React.Fragment>
+      <h2>Font Weights</h2>
+      <Table>
+        <Table.Head>
+          <Table.Row>
+            <Table.Header>Token</Table.Header>
+            <Table.Header>Value</Table.Header>
+          </Table.Row>
+        </Table.Head>
+        <Table.Body>{FontWeightRows()}</Table.Body>
+      </Table>
+    </React.Fragment>
+  )
+}
+
 function DesignTokensPage({location}) {
   return <Layout location={location}>
       <Row>
@@ -377,6 +423,7 @@ function DesignTokensPage({location}) {
           <ZIndex />
           <Spacing />
           <Shadows />
+          <FontWeight />
         </Col>
       </Row>
     </Layout>

--- a/docs-src/src/pages/design-tokens.js
+++ b/docs-src/src/pages/design-tokens.js
@@ -317,7 +317,7 @@ function Spacing() {
 function ShadowRows() {
   
   const rows = []
-  const shadows = DesignTokens.shadow
+  const shadows = DesignTokens.box.shadow
 
   for (const shadow in shadows) {
     const exampleStyle = {
@@ -366,7 +366,7 @@ function Shadows() {
 function FontWeightRows() {
 
   const rows = []
-  const fontWeights = DesignTokens.font
+  const fontWeights = DesignTokens.font.weight
 
   for (const weight in fontWeights) {
     const exampleStyle = {

--- a/docs-src/src/pages/design-tokens.js
+++ b/docs-src/src/pages/design-tokens.js
@@ -238,7 +238,7 @@ function ZIndexRows() {
         </Table.Data>
         <Table.Data>
           <Table.HeaderInline>Value:</Table.HeaderInline>
-          <pre>${zIndices[index].value}</pre>
+          <pre>{zIndices[index].value}</pre>
         </Table.Data>
       </Table.Row>
       )
@@ -273,7 +273,6 @@ function SpacingRows() {
 
   for (const space in spaces) {
     const exampleStyle = {
-      spacing: spaces[space].value,
       height: spaces[space].value,
       width: spaces[space].value,
     };
@@ -288,7 +287,7 @@ function SpacingRows() {
         <Table.Data>
           <Table.HeaderInline>Value:</Table.HeaderInline>
           <div style={exampleStyle}></div>
-          <pre>${spaces[space].value}</pre>
+          <pre>{spaces[space].value}</pre>
         </Table.Data>
       </Table.Row>
     )
@@ -321,7 +320,6 @@ function ShadowRows() {
 
   for (const shadow in shadows) {
     const exampleStyle = {
-      shadowing: shadows[shadow].value,
       width: '10rem',
       height: '3rem',
       border: '1px solid black',
@@ -338,7 +336,7 @@ function ShadowRows() {
         <Table.Data>
           <Table.HeaderInline>Value:</Table.HeaderInline>
           <div style={exampleStyle}></div>
-          <pre>${shadows[shadow].value}</pre>
+          <pre>{shadows[shadow].value}</pre>
         </Table.Data>
       </Table.Row>
     )

--- a/docs-src/src/pages/design-tokens.js
+++ b/docs-src/src/pages/design-tokens.js
@@ -254,7 +254,7 @@ function ZIndexRows() {
         </Table.Data>
         <Table.Data>
           <Table.HeaderInline>Value:</Table.HeaderInline>
-          <pre>{zIndices[index].value}</pre>
+          <pre>${zIndices[index].value}</pre>
         </Table.Data>
       </Table.Row>
       )
@@ -280,6 +280,37 @@ function ZIndex() {
   )
 }
 
+function SpacingRows() {
+
+  const rows = []
+  const spaces = DesignTokens.spacing
+
+  for (const space in spaces) {
+    const exampleStyle = {
+      spacing: spaces[space].value,
+      height: spaces[space].value,
+      width: spaces[space].value,
+    };
+
+    rows.push (
+      <Table.Row>
+        <Table.Data>
+          <Table.HeaderInline>Token:</Table.HeaderInline>
+          <pre>${spaces[space].name}</pre>
+          <p><i>{spaces[space].comment}</i></p>
+        </Table.Data>
+        <Table.Data>
+          <Table.HeaderInline>Value:</Table.HeaderInline>
+          <div style={exampleStyle}></div>
+          <pre>${spaces[space].value}</pre>
+        </Table.Data>
+      </Table.Row>
+    )
+  }
+
+  return rows
+}
+
 function Spacing() {
   return (
     <React.Fragment>
@@ -292,7 +323,7 @@ function Spacing() {
           </Table.Row>
         </Table.Head>
         <Table.Body>
-          <div style={DesignTokens.Spacing.value} />
+          {SpacingRows()}
         </Table.Body>
       </Table>
     </React.Fragment>
@@ -330,6 +361,7 @@ function DesignTokensPage({location}) {
           <FontSizes />
           <BorderRadius />
           <ZIndex />
+          <Spacing />
         </Col>
       </Row>
     </Layout>


### PR DESCRIPTION
This PR adds documentation examples for several other design tokens.  This PR is connected to [Issue # 486](https://github.com/revelrylabs/harmonium/issues/486).

Border Radius:
<img width="1075" alt="Screen Shot 2020-02-06 at 12 05 08 PM" src="https://user-images.githubusercontent.com/25229248/73965008-f17f2980-48d8-11ea-892f-20396b795536.png">

Z-Index is just a list of possible values:
<img width="1065" alt="Screen Shot 2020-02-06 at 12 07 10 PM" src="https://user-images.githubusercontent.com/25229248/73965144-3acf7900-48d9-11ea-9376-725a1c88dc2f.png">

Compared to an [example design token page](https://www.lightningdesignsystem.com/design-tokens/), our version of spacing looks different.  I'll address this with Laura/Design on a future ticket.  Spacing:

<img width="1075" alt="Screen Shot 2020-02-06 at 12 10 04 PM" src="https://user-images.githubusercontent.com/25229248/73965368-a0bc0080-48d9-11ea-9fa7-fe0c1cba031e.png">

For Shadows, this page is static in the same way the the [example design token page](https://www.lightningdesignsystem.com/design-tokens/) is.  Shadows:

<img width="1054" alt="Screen Shot 2020-02-06 at 12 11 00 PM" src="https://user-images.githubusercontent.com/25229248/73965476-dbbe3400-48d9-11ea-92da-56efbb87008f.png">

Font Weights:
<img width="1055" alt="Screen Shot 2020-02-06 at 12 12 09 PM" src="https://user-images.githubusercontent.com/25229248/73965521-f09ac780-48d9-11ea-998d-0efbcc68c41d.png">

