### PR TITLE
feature: harmonium cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ api.json
 /settings-templates/_harmonium-settings.scss
 /settings-templates/_color-palette.scss
 /settings-templates/settings-templates.zip
+harmonium.config.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.1.0] - 2020-02-20
+
+### Added
+
+- `harmonium init` for creating harmonium configuration files
+- `harmonium build` for creating assets from harmonium configuration files
+
 ## [6.0.0] - 2020-02-12
 
 - Add Design Tokens. These will allow for the application of Harmonium's styles in more than just web applications.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 [![Dependency Status](https://dependencyci.com/github/revelrylabs/harmonium/badge)](https://dependencyci.com/github/revelrylabs/harmonium)
 [![Coverage Status](https://opencov.prod.revelry.net/projects/8/badge.svg)](https://opencov.prod.revelry.net/projects/8)
 
-Harmonium is a framework of components optimized for teams that want to ship apps fast. It is a curated list of components that work together and have cohesive styles. One of our design goals is that you never have to research and handpick component packages. Whatever you need is already here.
+Harmonium is a framework of React components optimized for teams that want to ship apps fast. It is a curated list of components that work together and have cohesive styles. One of our design goals is that you never have to research and handpick component packages. Whatever you need is already here.
+
+Harmonium was built by [Revelry](https://revelry.co). We've been doing React since the earliest version was in beta. We've built dozens of React apps and we've learned what works and what doesn't. And our focus is on shipping gold fast. So we never want to solve the same problem twice.
 
 A gallery of components is at https://harmonium.revelry.co.
 
@@ -17,40 +19,106 @@ To install the toolkit for use in your project:
 npm install --save harmonium
 ```
 
-## Usage
+## SCSS Setup
+
+We've built a set of SCSS styles for all the components. In order to use Harmonium, make sure that your asset compilation pipeline can understand scss files.
+
+Import Harmonium's styles into your scss like so:
+
+```scss
+/* myapp.scss */
+@import '~harmonium/scss/app';
+/* your styles here; */
+```
+
+Harmonium includes !default values for color-palette and harmonium-settings vars. You can download the starter settings here (which include color-palette.scss and harmonium-settings.scss) and easily view/edit variables to fit your project
+
+Your style imports would look something like this:
+
+```scss
+/* myapp.scss */
+@import 'wherever-your-styles-live/color-palette';
+@import 'wherever-your-styles-live/harmonium-settings';
+@import 'wherever-your-styles-live/harmonium-component-settings';
+@import '~/harmonium/scss/app';
+/* your styles here; */
+```
+
+## Customization
+
+Harmonium's settings can be customized even further. By using harmonium's cli, you can create a configuration file to update the design token values used to create the `_color-palette.scss` and `_harmonium-settings.scss` used above.
+
+To create the configuration file, run:
+
+```sh
+npx harmonium init
+```
+
+This will create a file, `harmonium.config.js`, in the root of your project
+
+In this file you can update the values of the design tokens. You can also update the build path of the output
+
+To create the assets with the values you defined, run:
+
+```sh
+npx harmonium build
+```
+
+And they should be created in the build path specificed in `harmonium.config.js`
+
+## Usage with React
 
 You can import components and use components from the toolkit like:
 
 ```jsx
-import Col from 'harmonium/lib/Col'
+import React, {Component} from 'react'
 import Row from 'harmonium/lib/Row'
-import Callout from 'harmonium/lib/Callout'
-
-function Hello() {
-  return (
-    <Row>
-      <Col>
-        <Callout>Hello, world.</Callout>
-      </Col>
-    </Row>
-  )
+import Col from 'harmonium/lib/Col'
+import Button from 'harmonium/lib/Button'
+export default class MyComponent extends Component {
+  render() {
+    return (
+      <Row>
+        <Col>
+          <h3>Hello, world</h3>
+        </Col>
+        <Col>
+          <Button small>Click here</Button>
+        </Col>
+      </Row>
+    )
+  }
 }
+```
+
+## Usage with HTML
+
+If you aren't using React, you can still take advantage of Harmonium's components by adding the proper classes to your markup
+
+```html
+<div class="rev-Row">
+  <div class="rev-Col">
+    <h3>Hello, world</h3>
+  </div>
+  <div class="rev-Col">
+    <button class="rev-Button">Press me</button>
+  </div>
+</div>
+```
+
+A vanilla JavaScript file to use without React can be found at `src/vanilla/harmonium.js` inside of the Harmonium package. To add interactivity, make sure to include it on your page.
+
+```html
+<script type="module">
+  import {initializeAllComponents} from '/path/to/harmonium.js'
+  document.addEventListener('DOMContentLoaded', () => {
+    initializeAllComponents()
+  })
+</script>
 ```
 
 See the example site at https://harmonium.revelry.co for more examples of how to
 use the components in your projects.
-
-## SCSS
-
-We don't just provide JavaScript. We've built a set of SCSS styles for all the
-components. It is in the `scss` directory of the package. You can either copy it
-into your project's SCSS directory, or use a tool like [`sassy-npm-importer`](https://github.com/revelrylabs/sassy-npm-importer) to
-import it from the package.
-
-## Configuration
-
-At this time, there's no package level configuration-- all options are passed as
-props to the components at time of use.
 
 ## Contributing and Development
 

--- a/build.js
+++ b/build.js
@@ -1,91 +1,15 @@
-const StyleDictionary = require('style-dictionary')
 const fs = require('fs')
 const archiver = require('archiver')
-
-function fileHeader(options, commentStyle) {
-  let to_ret = ''
-  // for backward compatibility we need to have the user explicitly hide them
-
-  const showFileHeader = options ? options.showFileHeader : true
-
-  if (showFileHeader) {
-    if (commentStyle === 'short') {
-      to_ret += '\n'
-      to_ret += '// Do not edit directly\n'
-      to_ret += `// Generated on ${new Date().toUTCString()}\n`
-      to_ret += '\n'
-    } else {
-      to_ret += '/**\n'
-      to_ret += ' * Do not edit directly\n'
-      to_ret += ` * Generated on ${new Date().toUTCString()}\n`
-      to_ret += ' */\n\n'
-    }
-  }
-
-  return to_ret
-}
-
-function variablesWithPrefix(prefix, properties, suffix, commentStyle) {
-  return properties
-    .map((prop) => {
-      let to_ret_prop = `${prefix + prop.name}: ${
-        prop.attributes.category === 'asset'
-          ? `"${prop.value} ${suffix}"`
-          : `${prop.value} ${suffix}`
-      };`
-
-      if (prop.comment) {
-        if (commentStyle === 'short') {
-          to_ret_prop = to_ret_prop.concat(` // ${prop.comment}`)
-        } else {
-          to_ret_prop = to_ret_prop.concat(` /* ${prop.comment} */`)
-        }
-      }
-
-      return to_ret_prop
-    })
-    .filter((strVal) => {
-      return !!strVal
-    })
-    .join('\n')
-}
+const styleDictionary = require('./src/configuration/styleDictionary')
 
 /**
  * Reads in our design token files and
  * Exports them depending on the outputs from
  * design-tokens.config.json
+ * @returns {void}
  */
 function buildDesignTokens() {
-  StyleDictionary.registerTransformGroup({
-    name: 'docs',
-    transforms: ['attribute/cti', 'name/cti/kebab', 'size/rem', 'color/css'],
-  })
-
-  StyleDictionary.registerFormat({
-    name: 'scss/variables/default',
-    formatter(dictionary) {
-      return (
-        fileHeader(this.options, 'short') +
-        variablesWithPrefix('$', dictionary.allProperties, '!default', 'short')
-      )
-    },
-  })
-
-  // Since we are making a separate color palette file for sass,
-  // we want to filter those out
-  StyleDictionary.registerFilter({
-    name: 'isColor',
-    matcher(prop) {
-      return prop.attributes.category === 'color'
-    },
-  })
-
-  StyleDictionary.registerFilter({
-    name: 'isNotColor',
-    matcher(prop) {
-      return prop.attributes.category !== 'color'
-    },
-  })
+  const StyleDictionary = styleDictionary.prepareStyleDictionary()
 
   // APPLY THE CONFIGURATION
   // IMPORTANT: the registration of custom transforms
@@ -100,6 +24,7 @@ function buildDesignTokens() {
 
 /**
  * Generates our settings-templates zip file
+ * @returns {void}
  */
 function buildSettingsTemplatesArchive() {
   // create a file to stream archive data to.

--- a/docs-src/src/layouts/index.scss
+++ b/docs-src/src/layouts/index.scss
@@ -339,7 +339,6 @@ pre {
   white-space: pre;
   font-family: monospace;
   background-color: rgb(41, 45, 62);
-  margin: 0px;
   border: 0px;
   background: none;
   white-space: pre-wrap;

--- a/docs-src/src/pages/index.js
+++ b/docs-src/src/pages/index.js
@@ -81,15 +81,26 @@ const IndexPage = ({location}) => {
 
 /* your styles here; */`}
           language="scss" />
+
+          <h2>Customization</h2>
           <p>
-            For advanced configurations, styles can be found in the{' '}
-            <code>scss</code> directory of the package. You can either copy it
-            into your project&apos;s SCSS directory, or use a tool like{' '}
-            <a href="https://www.npmjs.com/package/sassy-npm-importer">
-              sassy-npm-importer
-            </a>{' '}
-            to import it from the package.
+            Harmonium's settings can be customized even further.
+            By using harmonium's cli, you can create a configuration file to update
+            the design token values used to create the <code>_color-palette.scss</code> and <code>_harmonium-settings.scss</code>
+            used above.
           </p>
+
+          <p>To create the configuration file, run:</p>
+          <CodeBlock language="bash" code={"npx harmonium init"} />
+
+          <p>This will create a file, <code>harmonium.config.js</code>, in the root of your project</p>
+
+          <p>In this file you can update the values of the design tokens. You can also update the build path of the output</p>
+
+          <p>To create the assets with the values you defined, run:</p>
+          <CodeBlock language="bash" code={"npx harmonium build"} />
+
+          <p>And they should be created in the build path specificed in <code>harmonium.config.js</code></p>
 
           <h2>Usage with React</h2>
           <CodeBlock language="jsx"

--- a/package.json
+++ b/package.json
@@ -11,13 +11,21 @@
     "breakpoint-sass": "^2.7.1",
     "chart.js": "^2.7.2",
     "classnames": "^2.2.5",
+    "commander": "^4.1.1",
+    "deepmerge": "^4.2.2",
+    "del": "^5.1.0",
+    "glob": "^7.1.6",
     "jquery": "^3.2.1",
     "lodash": "^4.17.5",
     "luxon": "^1.8.2",
     "prop-types": "^15.5.7",
     "react": ">=15.3.0",
     "react-dom": ">=15.3.0",
-    "sassy-npm-importer": "^3.0.0"
+    "sassy-npm-importer": "^3.0.0",
+    "tempy": "^0.4.0"
+  },
+  "bin": {
+    "harmonium": "./src/cli/index.js"
   },
   "scripts": {
     "clean": "rm -rf lib/",

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+
+const commander = require('commander')
+const fs = require('fs')
+const path = require('path')
+const program = new commander.Command()
+const packageInfo = require('./../../package.json')
+const configuration = require('./../configuration/index.js')
+const util = require('util')
+const {promisify} = require('util')
+
+program
+  .version(packageInfo.version)
+  .command('init')
+  .description('Creates a default harmonium.config.js is the current directory')
+  .option(
+    '-o, --outputPath [path]',
+    'the path and filename to make the config file'
+  )
+  .action(async (cmd) => {
+    const outputPath = cmd.outputPath
+      ? cmd.outputPath
+      : path.join(process.cwd(), 'harmonium.config.js')
+
+    const config = await configuration.createConfiguration()
+
+    const configModule = `module.exports = ${util.inspect(config, {
+      depth: null,
+    })}`
+
+    const writeFileAsync = promisify(fs.writeFile)
+
+    await writeFileAsync(outputPath, configModule)
+  })
+
+program.parse(process.argv)

--- a/src/configuration/index.js
+++ b/src/configuration/index.js
@@ -1,0 +1,84 @@
+const fs = require('fs')
+const path = require('path')
+const glob = require('glob')
+const {promisify} = require('util')
+const tempy = require('tempy')
+const merge = require('deepmerge')
+
+const rootPath = path.join(__dirname, '..', '..')
+
+const designTokensGlob = path.join(rootPath, 'design-tokens', '**', '*.json')
+
+const designTokensConfig = require(path.join(
+  rootPath,
+  'design-tokens.config.json'
+))
+
+/**
+ * Generates a Harmonium configuration object
+ * @returns {object} a new configuration object
+ */
+async function createConfiguration() {
+  const globAsync = promisify(glob)
+  const files = await globAsync(designTokensGlob)
+
+  let designTokenObject = {}
+
+  for (const file of files) {
+    const json = require(file)
+
+    designTokenObject = merge(designTokenObject, json)
+  }
+
+  return {
+    buildPath: './harmonium-settings',
+    designTokens: designTokenObject,
+  }
+}
+
+/**
+ * Merges 2 configuration items together
+ * If something in configurationA is also in configurationB,
+ * then the new configuration favors the item in configurationB
+ * @param {object} configurationA the first configuration
+ * @param {object} configurationB the second configuration
+ * @returns {object} a new configuration object
+ */
+function mergeConfiguration(configurationA, configurationB) {
+  return merge(configurationA, configurationB)
+}
+
+/**
+ * Generates assets based on the configuration
+ * @param {object} configuration the configuration used to build the assets
+ * @returns {void}
+ */
+async function createAssets(configuration) {
+  const tempFile = tempy.file({extension: 'json'})
+  const writeFileAsync = promisify(fs.writeFile)
+
+  await writeFileAsync(tempFile, JSON.stringify(configuration.designTokens))
+
+  let scss = designTokensConfig.platforms.scss
+
+  scss = merge(scss, {buildPath: configuration.buildPath})
+
+  const StyleDictionary = require('./styleDictionary')
+    .prepareStyleDictionary()
+    .extend({
+      source: [tempFile],
+      platforms: {
+        scss,
+      },
+    })
+
+  const result = StyleDictionary.buildAllPlatforms()
+
+  return result
+}
+
+module.exports = {
+  createConfiguration,
+  mergeConfiguration,
+  createAssets,
+}

--- a/src/configuration/index.js
+++ b/src/configuration/index.js
@@ -31,7 +31,7 @@ async function createConfiguration() {
   }
 
   return {
-    buildPath: './harmonium-settings',
+    buildPath: './harmonium-settings/',
     designTokens: designTokenObject,
   }
 }

--- a/src/configuration/styleDictionary.js
+++ b/src/configuration/styleDictionary.js
@@ -1,0 +1,88 @@
+const StyleDictionary = require('style-dictionary')
+
+function fileHeader(options, commentStyle) {
+  let to_ret = ''
+  // for backward compatibility we need to have the user explicitly hide them
+
+  const showFileHeader = options ? options.showFileHeader : true
+
+  if (showFileHeader) {
+    if (commentStyle === 'short') {
+      to_ret += '\n'
+      to_ret += '// Do not edit directly\n'
+      to_ret += `// Generated on ${new Date().toUTCString()}\n`
+      to_ret += '\n'
+    } else {
+      to_ret += '/**\n'
+      to_ret += ' * Do not edit directly\n'
+      to_ret += ` * Generated on ${new Date().toUTCString()}\n`
+      to_ret += ' */\n\n'
+    }
+  }
+
+  return to_ret
+}
+
+function variablesWithPrefix(prefix, properties, suffix, commentStyle) {
+  return properties
+    .map((prop) => {
+      let to_ret_prop = `${prefix + prop.name}: ${
+        prop.attributes.category === 'asset'
+          ? `"${prop.value} ${suffix}"`
+          : `${prop.value} ${suffix}`
+      };`
+
+      if (prop.comment) {
+        if (commentStyle === 'short') {
+          to_ret_prop = to_ret_prop.concat(` // ${prop.comment}`)
+        } else {
+          to_ret_prop = to_ret_prop.concat(` /* ${prop.comment} */`)
+        }
+      }
+
+      return to_ret_prop
+    })
+    .filter((strVal) => {
+      return !!strVal
+    })
+    .join('\n')
+}
+
+function prepareStyleDictionary() {
+  StyleDictionary.registerTransformGroup({
+    name: 'docs',
+    transforms: ['attribute/cti', 'name/cti/kebab', 'size/rem', 'color/css'],
+  })
+
+  StyleDictionary.registerFormat({
+    name: 'scss/variables/default',
+    formatter(dictionary) {
+      return (
+        fileHeader(this.options, 'short') +
+        variablesWithPrefix('$', dictionary.allProperties, '!default', 'short')
+      )
+    },
+  })
+
+  // Since we are making a separate color palette file for sass,
+  // we want to filter those out
+  StyleDictionary.registerFilter({
+    name: 'isColor',
+    matcher(prop) {
+      return prop.attributes.category === 'color'
+    },
+  })
+
+  StyleDictionary.registerFilter({
+    name: 'isNotColor',
+    matcher(prop) {
+      return prop.attributes.category !== 'color'
+    },
+  })
+
+  return StyleDictionary
+}
+
+module.exports = {
+  prepareStyleDictionary,
+}

--- a/src/configuration/test/index.test.js
+++ b/src/configuration/test/index.test.js
@@ -8,7 +8,7 @@ describe('Configuration', () => {
     it('creates a new Harmonium configuration object', async () => {
       const config = await Configuration.createConfiguration()
 
-      expect(config.buildPath).equal('./harmonium-settings')
+      expect(config.buildPath).equal('./harmonium-settings/')
       expect(config.hasOwnProperty('designTokens')).equal(true)
     })
   })
@@ -18,12 +18,12 @@ describe('Configuration', () => {
       const config1 = await Configuration.createConfiguration()
       const config2 = await Configuration.createConfiguration()
 
-      config2.buildPath = './not-harmonium-settings'
+      config2.buildPath = './not-harmonium-settings/'
       const mergedConfig = Configuration.mergeConfiguration(config1, config2)
 
-      expect(config1.buildPath).equal('./harmonium-settings')
-      expect(config2.buildPath).equal('./not-harmonium-settings')
-      expect(mergedConfig.buildPath).equal('./not-harmonium-settings')
+      expect(config1.buildPath).equal('./harmonium-settings/')
+      expect(config2.buildPath).equal('./not-harmonium-settings/')
+      expect(mergedConfig.buildPath).equal('./not-harmonium-settings/')
     })
   })
 

--- a/src/configuration/test/index.test.js
+++ b/src/configuration/test/index.test.js
@@ -1,0 +1,47 @@
+import Configuration from '../index'
+import tempy from 'tempy'
+import {promisify} from 'util'
+import fs from 'fs'
+
+describe('Configuration', () => {
+  describe('createConfiguration', () => {
+    it('creates a new Harmonium configuration object', async () => {
+      const config = await Configuration.createConfiguration()
+
+      expect(config.buildPath).equal('./harmonium-settings')
+      expect(config.hasOwnProperty('designTokens')).equal(true)
+    })
+  })
+
+  describe('mergeConfiguration', () => {
+    it('merges 2 configuration object', async () => {
+      const config1 = await Configuration.createConfiguration()
+      const config2 = await Configuration.createConfiguration()
+
+      config2.buildPath = './not-harmonium-settings'
+      const mergedConfig = Configuration.mergeConfiguration(config1, config2)
+
+      expect(config1.buildPath).equal('./harmonium-settings')
+      expect(config2.buildPath).equal('./not-harmonium-settings')
+      expect(mergedConfig.buildPath).equal('./not-harmonium-settings')
+    })
+  })
+
+  describe('createAssets', () => {
+    it('generates assets', async () => {
+      const config = await Configuration.createConfiguration()
+
+      const buildPath = `${tempy.directory()}/`
+
+      config.buildPath = buildPath
+
+      await Configuration.createAssets(config)
+
+      const readdirAsync = promisify(fs.readdir)
+      const files = await readdirAsync(buildPath)
+
+      expect(files).to.include('_harmonium-settings.scss')
+      expect(files).to.include('_color-palette.scss')
+    })
+  })
+})


### PR DESCRIPTION
connects to #489 

- adds a command line client to harmonium to allow for configuring design tokens and creating new template files based on them
- adds `harmonium init` command to create the initial configuration
- adds `harmonium build` command to generate the assets from the configuration
- adds a configuration module to create the configuration programmatically
