### PR TITLE
Feature: Add harmoniumDesignTokens.js as output of cli. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,6 @@ api.json
 /docs-src/static/settings-templates.zip
 /settings-templates/_harmonium-settings.scss
 /settings-templates/_color-palette.scss
+/settings-templates/harmoniumDesignTokens.js
 /settings-templates/settings-templates.zip
 harmonium.config.js

--- a/build.js
+++ b/build.js
@@ -73,6 +73,10 @@ function buildSettingsTemplatesArchive() {
     name: 'settings-templates/_harmonium-component-settings.scss',
   })
 
+  archive.file('settings-templates/harmoniumDesignTokens.js', {
+    name: 'settings-templates/harmoniumDesignTokens.js',
+  })
+
   archive.finalize()
 }
 

--- a/design-tokens.config.json
+++ b/design-tokens.config.json
@@ -42,6 +42,16 @@
           "format": "javascript/module"
         }
       ]
+    },
+    "js": {
+      "transformGroup": "js",
+      "buildPath": "./settings-templates/",
+      "files": [
+        {
+          "destination": "harmoniumDesignTokens.js",
+          "format": "javascript/module"
+        }
+      ]
     }
   }
 }

--- a/src/configuration/index.js
+++ b/src/configuration/index.js
@@ -61,7 +61,10 @@ async function createAssets(configuration) {
 
   let scss = designTokensConfig.platforms.scss
 
+  let jsPlatform = designTokensConfig.platforms.js
+
   scss = merge(scss, {buildPath: configuration.buildPath})
+  jsPlatform = merge(jsPlatform, {buildPath: configuration.buildPath})
 
   const StyleDictionary = require('./styleDictionary')
     .prepareStyleDictionary()
@@ -69,6 +72,7 @@ async function createAssets(configuration) {
       source: [tempFile],
       platforms: {
         scss,
+        jsPlatform,
       },
     })
 

--- a/src/configuration/test/index.test.js
+++ b/src/configuration/test/index.test.js
@@ -42,6 +42,7 @@ describe('Configuration', () => {
 
       expect(files).to.include('_harmonium-settings.scss')
       expect(files).to.include('_color-palette.scss')
+      expect(files).to.include('harmoniumDesignTokens.js')
     })
   })
 })


### PR DESCRIPTION
To be used with JS environments. This makes it so users can update the harmonium.config.js values and have those changes apply for both scss and for JavaScript environments. Such as React Native. Or any CSS-in-JS environments



