### PR TITLE
feature: added a default placeholder color variable for the Input com…

### DIFF
--- a/scss/components/_Input.scss
+++ b/scss/components/_Input.scss
@@ -1,3 +1,5 @@
+$input-placeholder-color: $color-muted !default;
+
 .rev-Input,
 .rev-DatePicker-input {
   @include input-style;

--- a/scss/mixins/_placeholders.scss
+++ b/scss/mixins/_placeholders.scss
@@ -1,21 +1,21 @@
-@mixin placeholder {
+@mixin placeholder($color: $input-placeholder-color) {
   &::-webkit-input-placeholder {
-    color: $color-muted;
+    color: $color;
     font-family: $body-font-family;
     font-weight: normal;
   }
   &:-moz-placeholder {
-    color: $color-muted;
+    color: $color;
     font-family: $body-font-family;
     font-weight: normal;
   }
   &::-moz-placeholder {
-    color: $color-muted;
+    color: $color;
     font-family: $body-font-family;
     font-weight: normal;
   }
   &:-ms-input-placeholder {
-    color: $color-muted;
+    color: $color;
     font-family: $body-font-family;
     font-weight: normal;
   }

--- a/settings-templates/_harmonium-component-settings.scss
+++ b/settings-templates/_harmonium-component-settings.scss
@@ -255,6 +255,7 @@ $input-radius: $border-radius-small;
 $input-color: $body-font-color;
 $input-color-focus: $input-color;
 $input-font-size: $font-size-base;
+$input-placeholder-color: $color-muted;
 $label-color: $body-font-color;
 $label-font-size: $font-size-base;
 


### PR DESCRIPTION
…ponent and added a color parameter to the placeholder mixin.

references issue #503

You are now able to change the placeholder color if needed through a few ways:
- Change the $input-placeholder-color in _harmonium-component-settings.scss from zip file.
- Use the harmonium cli to init/build new settings and add $input-placeholder-color to _harmonium-settings.scss (easier way).
- Use the placeholder mixin, that I added a parameter to, in your apps scss file. Which you're able to change just individual Inputs or all if needed.
e.g.
```jsx
<Input className="rev-Input--Foo" placeholder="foo" />`
```
then in your apps scss file for specific components
```scss
.rev-Input--Foo {
    @include placeholder($color-darker-gray);
}
```
