### PR TITLE
feature: Made the ButtonGroup expand the full-width of container when…

### DIFF
--- a/docs-src/src/examples/ButtonGroup.js.example
+++ b/docs-src/src/examples/ButtonGroup.js.example
@@ -8,5 +8,10 @@
       <Button>Two</Button>
       <Button>Three</Button>
     </ButtonGroup>
+    <ButtonGroup expanded>
+      <Button>One</Button>
+      <Button>Two</Button>
+      <Button>Three</Button>
+    </ButtonGroup>
   </Col>
 </div>

--- a/scss/components/_Buttons.scss
+++ b/scss/components/_Buttons.scss
@@ -191,6 +191,7 @@ $button-color-secondary-active: $color-white !default;
   font-size: 0;
 
   .rev-Button {
+    flex: auto;
     border-radius: 0;
     border-right: 1px solid $color-divider;
 
@@ -202,5 +203,9 @@ $button-color-secondary-active: $color-white !default;
       border: 0;
       border-radius: 0 $border-radius-small $border-radius-small 0;
     }
+  }
+
+  &.rev-ButtonGroup--expanded {
+    display: flex;
   }
 }

--- a/src/ButtonGroup.test.js
+++ b/src/ButtonGroup.test.js
@@ -21,7 +21,9 @@ describe('ButtonGroup', () => {
 
   it('should handle a props for different types of button groups', () => {
     const buttonGroup = shallow(<ButtonGroup secondary />)
+    const buttonGroupExpanded = shallow(<ButtonGroup expanded />)
 
     expect(buttonGroup.prop('className')).to.contain('secondary')
+    expect(buttonGroupExpanded.prop('className')).to.contain('expanded')
   })
 })


### PR DESCRIPTION
… the expanded prop is used and added an example.

references issue #506 

The props were already set up for expanded. So all I did add flex to the ButtonGroup, so that its child buttons take up the full-width of the container equally.

Also added an example on the docs page:
![Screen Shot 2020-03-14 at 11 19 28 AM](https://user-images.githubusercontent.com/7041126/76688187-9e477780-65f8-11ea-8bf5-1e9c5566d6b5.png)
