### PR TITLE
BREAKING CHANGE: Rename harmoniumDesignTokens.js to harmonium.tokens.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ api.json
 /docs-src/static/settings-templates.zip
 /settings-templates/_harmonium-settings.scss
 /settings-templates/_color-palette.scss
-/settings-templates/harmoniumDesignTokens.js
+/settings-templates/harmonium.tokens.js
 /settings-templates/settings-templates.zip
 harmonium.config.js
 harmonium-settings/

--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ api.json
 /docs-src/static/settings-templates.zip
 /settings-templates/_harmonium-settings.scss
 /settings-templates/_color-palette.scss
-/settings-templates/harmonium.tokens.js
+/settings-templates/harmonium-tokens.js
 /settings-templates/settings-templates.zip
 harmonium.config.js
 harmonium-settings/

--- a/build.js
+++ b/build.js
@@ -73,8 +73,8 @@ function buildSettingsTemplatesArchive() {
     name: 'settings-templates/_harmonium-component-settings.scss',
   })
 
-  archive.file('settings-templates/harmonium.tokens.js', {
-    name: 'settings-templates/harmonium.tokens.js',
+  archive.file('settings-templates/harmonium-tokens.js', {
+    name: 'settings-templates/harmonium-tokens.js',
   })
 
   archive.finalize()

--- a/build.js
+++ b/build.js
@@ -73,8 +73,8 @@ function buildSettingsTemplatesArchive() {
     name: 'settings-templates/_harmonium-component-settings.scss',
   })
 
-  archive.file('settings-templates/harmoniumDesignTokens.js', {
-    name: 'settings-templates/harmoniumDesignTokens.js',
+  archive.file('settings-templates/harmonium.tokens.js', {
+    name: 'settings-templates/harmonium.tokens.js',
   })
 
   archive.finalize()

--- a/design-tokens.config.json
+++ b/design-tokens.config.json
@@ -48,7 +48,7 @@
       "buildPath": "./settings-templates/",
       "files": [
         {
-          "destination": "harmonium.tokens.js",
+          "destination": "harmonium-tokens.js",
           "format": "javascript/module"
         }
       ]

--- a/design-tokens.config.json
+++ b/design-tokens.config.json
@@ -48,7 +48,7 @@
       "buildPath": "./settings-templates/",
       "files": [
         {
-          "destination": "harmoniumDesignTokens.js",
+          "destination": "harmonium.tokens.js",
           "format": "javascript/module"
         }
       ]

--- a/src/configuration/test/index.test.js
+++ b/src/configuration/test/index.test.js
@@ -24,8 +24,12 @@ describe('Configuration', () => {
       const mergedConfig = Configuration.mergeConfiguration(config1, config2)
 
       expect(config1.platforms.scss.buildPath).equal('./harmonium-settings/')
-      expect(config2.platforms.scss.buildPath).equal('./not-harmonium-settings/')
-      expect(mergedConfig.platforms.scss.buildPath).equal('./not-harmonium-settings/')
+      expect(config2.platforms.scss.buildPath).equal(
+        './not-harmonium-settings/'
+      )
+      expect(mergedConfig.platforms.scss.buildPath).equal(
+        './not-harmonium-settings/'
+      )
     })
   })
 
@@ -50,7 +54,7 @@ describe('Configuration', () => {
 
       expect(scssFiles).to.include('_harmonium-settings.scss')
       expect(scssFiles).to.include('_color-palette.scss')
-      expect(jsFiles).to.include('harmoniumDesignTokens.js')
+      expect(jsFiles).to.include('harmonium.tokens.js')
     })
   })
 })

--- a/src/configuration/test/index.test.js
+++ b/src/configuration/test/index.test.js
@@ -54,7 +54,7 @@ describe('Configuration', () => {
 
       expect(scssFiles).to.include('_harmonium-settings.scss')
       expect(scssFiles).to.include('_color-palette.scss')
-      expect(jsFiles).to.include('harmonium.tokens.js')
+      expect(jsFiles).to.include('harmonium-tokens.js')
     })
   })
 })


### PR DESCRIPTION
Renaming the JavaScript output. A (hopefully) better name to reduce confusion between it and the `harmonium.config.js` configuration file.
