### PR TITLE
Clarifying contributing dev setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,16 @@
 
 Clone and run `./bin/setup`.
 
+If you receive the message
+```
+asdf not found. Please make sure it is installed by following directions below and try again
+https://github.com/asdf-vm/asdf
+====================================
+Setup complete.
+====================================
+```
+This means the setup was not complete, go to https://github.com/asdf-vm/asdf and follow the getting started guide. Then rerun `./bin/setup`.
+
 ## Running the docs site locally
 
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harmonium",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "An opinionated React component framework for teams that move fast.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harmonium",
-  "version": "7.0.1",
+  "version": "7.0.0",
   "description": "An opinionated React component framework for teams that move fast.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- chore:
Made a slight edit to the contribution readme for anyone doing a first time setup.

The "setup complete" message in bash confused me for a hot minute since I thought the system was auto-downloading the asdf file it did not find, so thought including a message might reduce that for others.