### PR TITLE
Fix - Issue 332 active menu

### DIFF
--- a/docs-src/src/examples/Menu/Nested.js.example
+++ b/docs-src/src/examples/Menu/Nested.js.example
@@ -25,7 +25,7 @@
         <Menu.Item><a href="#">One</a>
           <Menu nested>
             <Menu.Item><a href="#">Nested One</a></Menu.Item>
-            <Menu.Item><a href="#">Nested Two</a>
+            <Menu.Item active><a href="#">Nested Two</a>
               <Menu nested>
                 <Menu.Item><a href="#">Double Nested One</a></Menu.Item>
                 <Menu.Item><a href="#">Double Nested Two</a></Menu.Item>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harmonium",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "An opinionated React component framework for teams that move fast.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harmonium",
-  "version": "7.0.1",
+  "version": "7.0.0",
   "description": "An opinionated React component framework for teams that move fast.",
   "repository": {
     "type": "git",

--- a/scss/components/_Menu.scss
+++ b/scss/components/_Menu.scss
@@ -116,7 +116,7 @@ $menu-dropdown-width: 24rem !default;
       }
     }
 
-    &[class*='--selected'] a {
+    &[class*='--selected'] > a {
       background-color: $menu-link-bkgd-selected;
       color: $menu-link-color-selected;
     }

--- a/scss/mixins/_colors.scss
+++ b/scss/mixins/_colors.scss
@@ -108,7 +108,7 @@ $navigation-color-disabled: $navigation-color !default; // will have disabled-op
     }
   }
 
-  &[class*='--selected'] a {
+  &[class*='--selected'] > a {
     background-color: $navigation-bkgd-selected;
 
     @if lightness($navigation-bkgd-selected)>65% {


### PR DESCRIPTION
Fixed the nested active menu bug by having the css selector only apply the style to a direct child. 

I kept in the "active" state on the "Nested.js.example" menu examples to confirm that is the correct behavior that should be displayed.

Also I did not use the conventional commits naming convention in my commit tree (ie having the commit start with fix), if I should fix that let me know.