### PR TITLE
Fixes #119: Closing the modal

### DIFF
--- a/docs-src/src/examples/Modal/Stateless.js.example
+++ b/docs-src/src/examples/Modal/Stateless.js.example
@@ -1,32 +1,35 @@
-React.createElement(
-class StatelessModalExample extends Component {
-  state = { isOpen: true };
 
-  openModal = () => {
-    this.setState({ isOpen: true })
+React.createElement(
+class Example extends Component {
+  constructor(props){
+    super(props)
+    this.state = {
+      isOpen: false,
+    }
   }
 
-  closeModal = () => {
-    this.setState({ isOpen: false })
+  open(){
+    this.setState({isOpen: true})
+  }
+
+  close(){
+    this.setState({isOpen: false})
   }
 
   render() {
     return (
       <div>
-        <Button style={{backgroundColor: 'black'}} onClick={() => this.openModal()}>Open Modal</Button>
-        <StatelessModal isOpen={this.state.isOpen} onBackgroundClick={() => this.closeModal()}>
+      <Button onClick={() => this.open()}>Open the modal</Button>
+      {this.state.isOpen && 
+        <StatelessModal isOpen={this.state.isOpen} onBackgroundClick={() => this.close()}>
           <Row>
             <Col>
-              <h1>Modal Example</h1>
-              <p>Click the background or the close button to dismiss the modal.</p>
+              <h2>Stateless modal Example</h2>
+              <p>Click the background or the close button to dismiss this Stateless Modal.</p>
             </Col>
           </Row>
-          <CloseButton
-          absolute
-          aria-label="Close Callout"
-          onClick={() => this.closeModal()}>&times;</CloseButton
-          >
         </StatelessModal>
+      }
       </div>
     )
   }

--- a/docs-src/src/examples/Modal/WithBackgroundClick.js.example
+++ b/docs-src/src/examples/Modal/WithBackgroundClick.js.example
@@ -1,10 +1,39 @@
-<div className="FakeViewportContainer">
-  <Modal isOpen={true}>
-    <Row>
-      <Col>
-        <h2>Modal Example</h2>
-        <p>Click the background to dismiss the modal.</p>
-      </Col>
-    </Row>
-  </Modal>
-</div>
+React.createElement(
+class Example extends Component {
+  constructor(props){
+    super(props)
+    this.state = {
+      isOpen: false,
+    }
+  }
+
+  open(){
+    this.setState({isOpen: true})
+  }
+
+  close(){
+    this.setState({isOpen: false})
+  }
+
+  render() {
+    return (
+      <div>
+        <Button onClick={() => this.open()}>Open the modal</Button>
+        {this.state.isOpen && 
+        <Modal isOpen={this.state.isOpen} onBackgroundClick={() => this.close()}>
+          <Row>
+            <Col>
+              <h2>Modal Example</h2>
+              <p>Click the background or the close button to dismiss this Modal.</p>
+            </Col>
+          </Row>
+        </Modal>
+
+        }
+      </div>
+    )
+  }
+}
+)
+
+

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -1,7 +1,5 @@
 import React, {Component} from 'react'
 import PropTypes from 'prop-types'
-import StatelessModal from './StatelessModal'
-import CloseButton from './CloseButton'
 
 export default class Modal extends Component {
   static propTypes = {
@@ -18,7 +16,7 @@ export default class Modal extends Component {
   }
 
   handleClick = (e) => {
-    this.setState({isOpen: false})
+    this.setState({isOpen: !this.isOpen})
     if (this.props.onBackgroundClick) {
       this.props.onBackgroundClick(e)
     }

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -1,5 +1,6 @@
 import React, {Component} from 'react'
 import PropTypes from 'prop-types'
+import StatelessModal from './StatelessModal';
 
 export default class Modal extends Component {
   static propTypes = {
@@ -16,7 +17,7 @@ export default class Modal extends Component {
   }
 
   handleClick = (e) => {
-    this.setState({isOpen: !this.isOpen})
+    this.setState({isOpen: false})
     if (this.props.onBackgroundClick) {
       this.props.onBackgroundClick(e)
     }

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -12,7 +12,7 @@ export default class Modal extends Component {
   constructor(props) {
     super(props)
     this.state = {
-      isOpen: props.isOpen,
+      isOpen: props.isOpen || false,
     }
   }
 

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -1,6 +1,7 @@
 import React, {Component} from 'react'
 import PropTypes from 'prop-types'
 import StatelessModal from './StatelessModal'
+import CloseButton from './CloseButton'
 
 export default class Modal extends Component {
   static propTypes = {
@@ -29,6 +30,7 @@ export default class Modal extends Component {
     return (
       <StatelessModal isOpen={isOpen} onBackgroundClick={this.handleClick}>
         {this.props.children}
+        <CloseButton onClick={this.handleClick}>Close</CloseButton>
       </StatelessModal>
     )
   }

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -30,7 +30,6 @@ export default class Modal extends Component {
     return (
       <StatelessModal isOpen={isOpen} onBackgroundClick={this.handleClick}>
         {this.props.children}
-        <CloseButton onClick={this.handleClick}>Close</CloseButton>
       </StatelessModal>
     )
   }

--- a/src/Modal.test.js
+++ b/src/Modal.test.js
@@ -36,4 +36,13 @@ describe('Modal', () => {
     expect(modal.state('isOpen')).to.eq(false)
     expect(spy.called).to.eq(true)
   })
+
+  it('should default to closed', () => {
+    const modal = shallow(
+      <Modal>
+        <h2>Some Content</h2>
+      </Modal>
+    )
+    expect(modal.state('isOpen')).to.eq(false)
+  })
 })

--- a/src/StatelessModal.js
+++ b/src/StatelessModal.js
@@ -1,6 +1,7 @@
 import React, {Component} from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
+import CloseButton from './CloseButton'
 
 export default class StatelessModal extends Component {
   static propTypes = {
@@ -36,7 +37,9 @@ export default class StatelessModal extends Component {
           onKeyPress={this.onBackgroundClick}
           tabIndex={0}
         />
-        <div className="rev-Modal-content">{this.props.children}</div>
+        <div className="rev-Modal-content">{this.props.children}
+          <CloseButton onClick={this.onBackgroundClick}>Close</CloseButton>
+        </div>
       </div>
     )
   }


### PR DESCRIPTION
--When looking at the Modal page, neither modal will pop up; they default to closed
--There are now two buttons, which will open up the respective modal when clicked
--Each modal can be closed by clicking the background, or by clicking the 'close modal' button that I added
--I was able to test the changes in Edge, Chrome, and Firefox; I couldn't test in Internet Explorer
