### PR TITLE
chore: Remove broken badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![NPM Version][npm-badge]][npm-url]
 [![Travis Build Status][travis-badge]][travis-url]
-[![Dependency Status](https://dependencyci.com/github/revelrylabs/harmonium/badge)](https://dependencyci.com/github/revelrylabs/harmonium)
 [![Coverage Status](https://opencov.prod.revelry.net/projects/8/badge.svg)](https://opencov.prod.revelry.net/projects/8)
 
 Harmonium is a framework of React components optimized for teams that want to ship apps fast. It is a curated list of components that work together and have cohesive styles. One of our design goals is that you never have to research and handpick component packages. Whatever you need is already here.


### PR DESCRIPTION
The badge for <https://dependencyci.com/> is broken due to the company being bought by Tidelift so we can probably remove it?