### PR TITLE
#673 Removed Invalid Syntax from GH Actions Deploy Workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
-      registry-url: 'https://registry.npmjs.org'
       with:
         node-version: 16
     - run: npm install


### PR DESCRIPTION
#673

Removed line of invalid syntax inadvertently left in GH Actions deploy workflow.