### PR TITLE
Engineering 245 - changed deploy conditions to tag OR push to master

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,13 +3,13 @@ name: Deploy
 on:
   push:
     tags: [ 'v*.*.*' ]
+    branches: master
 
 jobs:
   test:
     uses: ./.github/workflows/test.yml
   deploy:
     needs: [test]
-    if: ${{ github.ref_name == 'master' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
https://github.com/revelrylabs/engineering/issues/245

Thought the 8.0.3 tag + a push to master was going to trigger a deploy, but no dice. @grossvogel mentioned tagging being ok deploy conditions to enable the support of multiple versions at once.
